### PR TITLE
Fix retain + delete for embed cases

### DIFF
--- a/lib/delta/op.ex
+++ b/lib/delta/op.ex
@@ -51,6 +51,7 @@ defmodule Delta.Op do
     end
   end
 
+  @spec get_embed_data!(map, map) :: {any, any, any}
   def get_embed_data!(a, b) do
     cond do
       not is_map(a) ->
@@ -73,7 +74,7 @@ defmodule Delta.Op do
 
     composed =
       case {info(op1), info(op2)} do
-        {{"retain", :number}, {"delete", :number}} ->
+        {{"retain", _type}, {"delete", :number}} ->
           op2
 
         {{"retain", :map}, {"retain", :number}} ->

--- a/test/delta/delta/compose_test.exs
+++ b/test/delta/delta/compose_test.exs
@@ -293,5 +293,13 @@ defmodule Tests.Delta.Compose do
 
       assert Delta.compose(a, b) == expected
     end
+
+    test "delete a retain" do
+      a = [Op.retain(%{"delta" => [Op.insert("a")]})]
+      b = [Op.delete(1)]
+      expected = [Op.delete(1)]
+
+      assert Delta.compose(a, b) == expected
+    end
   end
 end


### PR DESCRIPTION
This PR fixes an issue that embed-retains not being deleted.

An example case:

```elixir
base = [Op.retain(%{ "table" => %{} })]
change = [Op.insert("a"), Op.delete(1)]
Delta.compose(base, change)
```

The `change` should delete the retain in `base`. However, in the current implementation, the result is an empty list.

### Test plan

Make sure the added test case makes sense and make sure tests pass.