### PR TITLE
Add Delta.slice_max which doesn't raise

### DIFF
--- a/lib/delta/utils.ex
+++ b/lib/delta/utils.ex
@@ -1,0 +1,25 @@
+defmodule Delta.Utils do
+  def slices_likely_cut_emoji?(left, right) do
+    left
+    |> to_charlist()
+    |> Enum.reverse()
+    |> do_slices_likely_cut_emoji?(to_charlist(right))
+  end
+
+  @zero_width_joiner 0x200D
+  defp do_slices_likely_cut_emoji?([l | _], [r | _])
+       when r == @zero_width_joiner or l == @zero_width_joiner,
+       do: true
+
+  @variation_selector_16 0xFE0F
+  defp do_slices_likely_cut_emoji?(_, [r | _]) when r == @variation_selector_16, do: true
+
+  # we don't have to account for hair modifiers as they use ZWJ
+  @skin_tone_modifiers 0x1F3FB..0x1F3FF
+  defp do_slices_likely_cut_emoji?(_, [r | _]) when r in @skin_tone_modifiers, do: true
+
+  @tags 0xE0001..0xE007F
+  defp do_slices_likely_cut_emoji?(_, [r | _]) when r in @tags, do: true
+
+  defp do_slices_likely_cut_emoji?(_, _), do: false
+end

--- a/test/delta/delta/transform_position_test.exs
+++ b/test/delta/delta/transform_position_test.exs
@@ -47,4 +47,3 @@ defmodule Tests.Delta.TransformPosition do
     assert Delta.transform(4, delta) == 1
   end
 end
-

--- a/test/delta/delta/transform_test.exs
+++ b/test/delta/delta/transform_test.exs
@@ -143,4 +143,3 @@ defmodule Tests.Delta.Transform do
     end
   end
 end
-

--- a/test/delta/delta_test.exs
+++ b/test/delta/delta_test.exs
@@ -69,6 +69,137 @@ defmodule Tests.Delta do
     end
   end
 
+  describe ".slice_max/3" do
+    test "slice across" do
+      delta = [
+        %{"insert" => "ABC"},
+        %{"insert" => "012", "attributes" => %{bold: true}},
+        %{"insert" => "DEF"}
+      ]
+
+      assert Delta.slice_max(delta, 1, 7) == [
+               %{"insert" => "BC"},
+               %{"insert" => "012", "attributes" => %{bold: true}},
+               %{"insert" => "DE"}
+             ]
+    end
+
+    test "slice boundaries" do
+      delta = [
+        %{"insert" => "ABC"},
+        %{"insert" => "012", "attributes" => %{bold: true}},
+        %{"insert" => "DEF"}
+      ]
+
+      assert Delta.slice_max(delta, 3, 3) == [
+               %{"insert" => "012", "attributes" => %{bold: true}}
+             ]
+    end
+
+    test "slice middle" do
+      delta = [
+        %{"insert" => "ABC"},
+        %{"insert" => "012", "attributes" => %{bold: true}},
+        %{"insert" => "DEF"}
+      ]
+
+      assert Delta.slice_max(delta, 4, 1) == [
+               %{"insert" => "1", "attributes" => %{bold: true}}
+             ]
+    end
+
+    test "slice normal emoji" do
+      delta = [%{"insert" => "01🙋45"}]
+      assert Delta.slice_max(delta, 1, 4) == [%{"insert" => "1🙋4"}]
+    end
+
+    test "slice emoji with zero width joiner" do
+      delta = [%{"insert" => "01🙋‍♂️78"}]
+      assert Delta.slice_max(delta, 1, 7) == [%{"insert" => "1🙋‍♂️7"}]
+    end
+
+    test "slice emoji with joiner and modifer" do
+      delta = [%{"insert" => "01🙋🏽‍♂️90"}]
+      assert Delta.slice_max(delta, 1, 9) == [%{"insert" => "1🙋🏽‍♂️9"}]
+    end
+
+    test "slice with 0 index" do
+      delta = [Op.insert("12")]
+      assert Delta.slice_max(delta, 0, 1) == [%{"insert" => "1"}]
+    end
+
+    test "slice insert object with 0 index" do
+      delta = [Op.insert(%{"id" => "1"}), Op.insert(%{"id" => "2"})]
+      assert Delta.slice_max(delta, 0, 1) == [%{"insert" => %{"id" => "1"}}]
+    end
+
+    test "slice emoji: codepoint + variation selector" do
+      # "01☹️345"
+      delta = [%{"insert" => "01\u2639\uFE0F345"}]
+      assert Delta.slice_max(delta, 1, 2) == [%{"insert" => "1"}]
+      assert Delta.slice_max(delta, 1, 3) == [%{"insert" => "1\u2639\uFE0F"}]
+    end
+
+    test "slice emoji: codepoint + skin tone modifier" do
+      # "01🤵🏽345"
+      delta = [%{"insert" => "01\u{1F935}\u{1F3FD}345"}]
+      assert Delta.slice_max(delta, 1, 2) == [%{"insert" => "1"}]
+      assert Delta.slice_max(delta, 1, 3) == [%{"insert" => "1"}]
+      assert Delta.slice_max(delta, 1, 4) == [%{"insert" => "1"}]
+      assert Delta.slice_max(delta, 1, 5) == [%{"insert" => "1\u{1F935}\u{1F3FD}"}]
+    end
+
+    test "slice emoji: codepoint + ZWJ + codepoint" do
+      # "01👨‍🏭345"
+      delta = [%{"insert" => "01\u{1F468}\u200D\u{1F3ED}345"}]
+      assert Delta.slice_max(delta, 1, 2) == [%{"insert" => "1"}]
+      assert Delta.slice_max(delta, 1, 3) == [%{"insert" => "1"}]
+      assert Delta.slice_max(delta, 1, 4) == [%{"insert" => "1"}]
+      assert Delta.slice_max(delta, 1, 5) == [%{"insert" => "1"}]
+      assert Delta.slice_max(delta, 1, 6) == [%{"insert" => "1\u{1F468}\u200D\u{1F3ED}"}]
+    end
+
+    test "slice emoji: flags" do
+      # "01🇦🇺345"
+      delta = [%{"insert" => "01\u{1F1E6}\u{1F1FA}345"}]
+      assert Delta.slice_max(delta, 1, 2) == [%{"insert" => "1"}]
+      # "1🇦"
+      assert Delta.slice_max(delta, 1, 3) == [%{"insert" => "1\u{1F1E6}"}]
+      # "1🇦"
+      assert Delta.slice_max(delta, 1, 4) == [%{"insert" => "1\u{1F1E6}"}]
+      # "1🇦🇺"
+      assert Delta.slice_max(delta, 1, 5) == [%{"insert" => "1\u{1F1E6}\u{1F1FA}"}]
+    end
+
+    test "slice emoji: tag sequence" do
+      # "01🏴󠁧󠁢󠁳󠁣󠁴󠁿345"
+      delta = [
+        %{"insert" => "01\u{1F3F4}\u{E0067}\u{E0062}\u{E0073}\u{E0063}\u{E0074}\u{E007F}345"}
+      ]
+
+      for len <- 2..14 do
+        assert Delta.slice_max(delta, 1, len) == [%{"insert" => "1"}]
+      end
+
+      assert Delta.slice_max(delta, 1, 15) == [
+               %{"insert" => "1\u{1F3F4}\u{E0067}\u{E0062}\u{E0073}\u{E0063}\u{E0074}\u{E007F}"}
+             ]
+    end
+
+    test "slice complex emoji" do
+      # "01🚵🏻‍♀️345"
+      delta = [%{"insert" => "01\u{1F6B5}\u{1F3FB}\u{200D}\u{2640}\u{FE0F}345"}]
+
+      for len <- 2..7 do
+        assert Delta.slice_max(delta, 1, len) == [%{"insert" => "1"}]
+      end
+
+      assert Delta.slice_max(delta, 1, 8) == [
+               %{"insert" => "1\u{1F6B5}\u{1F3FB}\u{200D}\u{2640}\u{FE0F}"}
+             ]
+    end
+  end
+
   describe ".push/2" do
     test "push merge" do
       delta =


### PR DESCRIPTION
The goal here is to have a safe version of `slice/2` that will return smaller slice instead of raising in case resulting slices aren't valid UTF-8 strings.

Since the actual code is in `Op.take_partial`, we introduce a boolean option `safe` that we pipe all the way from `slice_max` to `take_partial`.

There is also some home brew code which makes a best effort attempt to not slice grapheme cluster emojis in half. Country flags require some advanced heuristics, so this case is not covered. When working with emojis I was mainly consulting [this excellent blog post](https://tonsky.me/blog/emoji/), so if you're aware of cases not covered by it please do let me know!