### PR TITLE
Delete attributes

### DIFF
--- a/lib/delta.ex
+++ b/lib/delta.ex
@@ -95,7 +95,15 @@ defmodule Delta do
   defp do_push(op, %{"insert" => ""}), do: op
   defp do_push(op, %{"retain" => 0}), do: op
 
-  defp do_push(%{"delete" => left}, %{"delete" => right}) do
+  defp do_push(%{"delete" => left, "attributes" => attr}, %{
+         "delete" => right,
+         "attributes" => attr
+       }) do
+    Op.delete(left + right, attr)
+  end
+
+  defp do_push(%{"delete" => left} = last_op, %{"delete" => right} = op)
+       when map_size(last_op) == 1 and map_size(op) == 1 do
     Op.delete(left + right)
   end
 

--- a/lib/delta/op.ex
+++ b/lib/delta/op.ex
@@ -194,8 +194,8 @@ defmodule Delta.Op do
     end
   end
 
-  defp take_partial(%{"delete" => full}, length, _opts) do
-    {delete(length), delete(full - length)}
+  defp take_partial(%{"delete" => full} = op, length, _opts) do
+    {delete(length, op["attributes"]), delete(full - length, op["attributes"])}
   end
 
   defp take_partial(%{"retain" => full} = op, length, _opts) do

--- a/lib/delta/op.ex
+++ b/lib/delta/op.ex
@@ -3,7 +3,6 @@ defmodule Delta.Op do
   alias Delta.Utils
 
   def new(action, value, attr \\ false)
-  def new("delete", length, _attr), do: %{"delete" => length}
 
   def new(action, value, %{} = attr) when map_size(attr) > 0 do
     %{action => value, "attributes" => attr}
@@ -13,7 +12,7 @@ defmodule Delta.Op do
 
   def insert(value, attr \\ false), do: new("insert", value, attr)
   def retain(value, attr \\ false), do: new("retain", value, attr)
-  def delete(value), do: new("delete", value)
+  def delete(value, attr \\ false), do: new("delete", value, attr)
 
   def has_attributes?(%{"attributes" => %{}}), do: true
   def has_attributes?(_), do: false

--- a/test/delta/delta/compose_test.exs
+++ b/test/delta/delta/compose_test.exs
@@ -58,6 +58,22 @@ defmodule Tests.Delta.Compose do
       assert Delta.compose(a, b) == expected
     end
 
+    test "delete + delete different attributes" do
+      a = [Op.delete(1, %{"foo" => true})]
+      b = [Op.delete(1, %{"bar" => true})]
+      expected = [Op.delete(1, %{"foo" => true}), Op.delete(1, %{"bar" => true})]
+
+      assert Delta.compose(a, b) == expected
+    end
+
+    test "delete + delete same attributes" do
+      a = [Op.delete(1, %{"foo" => true})]
+      b = [Op.delete(1, %{"foo" => true})]
+      expected = [Op.delete(2, %{"foo" => true})]
+
+      assert Delta.compose(a, b) == expected
+    end
+
     test "retain + insert" do
       a = [Op.retain(1, %{"color" => "blue"})]
       b = [Op.insert("B")]

--- a/test/delta/delta/transform_test.exs
+++ b/test/delta/delta/transform_test.exs
@@ -19,9 +19,9 @@ defmodule Tests.Delta.Transform do
 
     test "insert + delete" do
       a = [Op.insert("A")]
-      b = [Op.delete(1)]
+      b = [Op.delete(1, %{"author" => "one"})]
 
-      assert Delta.transform(a, b) == [Op.retain(1), Op.delete(1)]
+      assert Delta.transform(a, b) == [Op.retain(1), Op.delete(1, %{"author" => "one"})]
     end
 
     test "delete + insert" do
@@ -39,7 +39,8 @@ defmodule Tests.Delta.Transform do
     end
 
     test "delete + delete" do
-      a = b = [Op.delete(1)]
+      a = [Op.delete(1, %{"author" => "one"})]
+      b = [Op.delete(1, %{"author" => "two"})]
 
       assert Delta.transform(a, b) == []
     end
@@ -82,13 +83,20 @@ defmodule Tests.Delta.Transform do
     end
 
     test "alternating edits" do
-      a = [Op.retain(2), Op.insert("si"), Op.delete(5)]
-      b = [Op.retain(1), Op.insert("e"), Op.delete(5), Op.retain(1), Op.insert("ow")]
+      a = [Op.retain(2), Op.insert("si"), Op.delete(5, %{"author" => "one"})]
+
+      b = [
+        Op.retain(1),
+        Op.insert("e"),
+        Op.delete(5, %{"author" => "two"}),
+        Op.retain(1),
+        Op.insert("ow")
+      ]
 
       assert Delta.transform(a, b, false) == [
                Op.retain(1),
                Op.insert("e"),
-               Op.delete(1),
+               Op.delete(1, %{"author" => "two"}),
                Op.retain(2),
                Op.insert("ow")
              ]
@@ -96,7 +104,7 @@ defmodule Tests.Delta.Transform do
       assert Delta.transform(b, a, false) == [
                Op.retain(2),
                Op.insert("si"),
-               Op.delete(1)
+               Op.delete(1, %{"author" => "one"})
              ]
     end
 
@@ -117,10 +125,10 @@ defmodule Tests.Delta.Transform do
     end
 
     test "trailing deletes with differing lengths" do
-      a = [Op.retain(2), Op.delete(1)]
-      b = [Op.delete(3)]
+      a = [Op.retain(2), Op.delete(1, %{"author" => "one"})]
+      b = [Op.delete(3, %{"author" => "two"})]
 
-      assert Delta.transform(a, b, false) == [Op.delete(2)]
+      assert Delta.transform(a, b, false) == [Op.delete(2, %{"author" => "two"})]
       assert Delta.transform(b, a, false) == []
     end
   end

--- a/test/delta/delta/transform_test.exs
+++ b/test/delta/delta/transform_test.exs
@@ -74,6 +74,13 @@ defmodule Tests.Delta.Transform do
       assert Delta.transform(a, b, true) == b
     end
 
+    test "retain + delete (with attributes)" do
+      a = [Op.retain(1, %{"color" => "blue"})]
+      b = [Op.delete(1, %{"foo" => true})]
+
+      assert Delta.transform(a, b, true) == b
+    end
+
     test "alternating edits" do
       a = [Op.retain(2), Op.insert("si"), Op.delete(5)]
       b = [Op.retain(1), Op.insert("e"), Op.delete(5), Op.retain(1), Op.insert("ow")]

--- a/test/delta/op_test.exs
+++ b/test/delta/op_test.exs
@@ -1,0 +1,178 @@
+defmodule Tests.Op do
+  use ExUnit.Case, async: true
+
+  alias Delta.Op
+
+  describe ".compose/2 : retain + delete" do
+    test "retain + delete" do
+      a = Op.retain(1)
+      b = Op.delete(1)
+
+      assert Op.compose(a, b) == {Op.delete(1), false, false}
+    end
+
+    test "retain + bigger delete" do
+      a = Op.retain(1)
+      b = Op.delete(2)
+
+      assert Op.compose(a, b) == {Op.delete(1), false, Op.delete(1)}
+    end
+
+    test "retain + smaller delete" do
+      a = Op.retain(2)
+      b = Op.delete(1)
+
+      assert Op.compose(a, b) == {Op.delete(1), Op.retain(1), false}
+    end
+
+    test "retain with attributes + bigger delete" do
+      a = Op.retain(1, %{"foo" => true})
+      b = Op.delete(2)
+
+      assert Op.compose(a, b) == {Op.delete(1), false, Op.delete(1)}
+    end
+
+    test "retain with attributes + smaller delete" do
+      a = Op.retain(2, %{"foo" => true})
+      b = Op.delete(1)
+
+      assert Op.compose(a, b) == {Op.delete(1), Op.retain(1, %{"foo" => true}), false}
+    end
+  end
+
+  describe ".compose/2 : retain + retain" do
+    test "retain + retain" do
+      a = Op.retain(1)
+      b = Op.retain(1)
+
+      assert Op.compose(a, b) == {Op.retain(1), false, false}
+    end
+
+    test "retain + retain with attributes" do
+      a = Op.retain(1, %{"foo" => true})
+      b = Op.retain(1, %{"bar" => true})
+
+      assert Op.compose(a, b) == {Op.retain(1, %{"foo" => true, "bar" => true}), false, false}
+    end
+
+    test "retain + bigger retain" do
+      a = Op.retain(1)
+      b = Op.retain(2)
+
+      assert Op.compose(a, b) == {Op.retain(1), false, Op.retain(1)}
+    end
+
+    test "retain + smaller retain" do
+      a = Op.retain(2)
+      b = Op.retain(1)
+
+      assert Op.compose(a, b) == {Op.retain(1), Op.retain(1), false}
+    end
+
+    test "retain + bigger retain with attributes" do
+      a = Op.retain(1)
+      b = Op.retain(2, %{"foo" => true})
+
+      assert Op.compose(a, b) ==
+               {Op.retain(1, %{"foo" => true}), false, Op.retain(1, %{"foo" => true})}
+    end
+
+    test "retain + smaller retain with attributes" do
+      a = Op.retain(2)
+      b = Op.retain(1, %{"foo" => true})
+
+      assert Op.compose(a, b) == {Op.retain(1, %{"foo" => true}), Op.retain(1), false}
+    end
+
+    test "retain + bigger retain both with attributes" do
+      a = Op.retain(1, %{"bar" => true})
+      b = Op.retain(2, %{"foo" => true})
+
+      assert Op.compose(a, b) ==
+               {Op.retain(1, %{"foo" => true, "bar" => true}), false,
+                Op.retain(1, %{"foo" => true})}
+    end
+  end
+
+  describe ".compose/2 : insert + retain" do
+    test "insert + retain" do
+      a = Op.insert("A")
+      b = Op.retain(1)
+
+      assert Op.compose(a, b) == {Op.insert("A"), false, false}
+    end
+
+    test "insert + smaller retain" do
+      a = Op.insert("Hello")
+      b = Op.retain(4)
+
+      assert Op.compose(a, b) == {Op.insert("Hell"), Op.insert("o"), false}
+    end
+
+    test "insert + bigger retain" do
+      a = Op.insert("Hello")
+      b = Op.retain(6)
+
+      assert Op.compose(a, b) == {Op.insert("Hello"), false, Op.retain(1)}
+    end
+
+    test "insert + retain both with attributes" do
+      a = Op.insert("A", %{"foo" => true})
+      b = Op.retain(1, %{"bar" => true})
+
+      assert Op.compose(a, b) == {Op.insert("A", %{"foo" => true, "bar" => true}), false, false}
+    end
+
+    test "insert + smaller retain with attributes" do
+      a = Op.insert("Hello")
+      b = Op.retain(4, %{"foo" => true})
+
+      assert Op.compose(a, b) == {Op.insert("Hell", %{"foo" => true}), Op.insert("o"), false}
+    end
+
+    test "insert + bigger retain with attributes" do
+      a = Op.insert("Hello")
+      b = Op.retain(6, %{"foo" => true})
+
+      assert Op.compose(a, b) ==
+               {Op.insert("Hello", %{"foo" => true}), false, Op.retain(1, %{"foo" => true})}
+    end
+
+    test "insert + smaller retain both with attributes" do
+      a = Op.insert("Hello", %{"foo" => true})
+      b = Op.retain(4, %{"bar" => true})
+
+      assert Op.compose(a, b) ==
+               {Op.insert("Hell", %{"foo" => true, "bar" => true}),
+                Op.insert("o", %{"foo" => true}), false}
+    end
+
+    test "insert + bigger retain both with attributes" do
+      a = Op.insert("Hello", %{"foo" => true})
+      b = Op.retain(6, %{"bar" => true})
+
+      assert Op.compose(a, b) ==
+               {Op.insert("Hello", %{"foo" => true, "bar" => true}), false,
+                Op.retain(1, %{"bar" => true})}
+    end
+  end
+
+  describe ".compose/2 unsupported" do
+    test "delete on the left" do
+      delete = Op.delete(1)
+      retain = Op.retain(1)
+      insert = Op.insert("A")
+
+      assert Op.compose(delete, retain) == {false, false, false}
+      assert Op.compose(delete, insert) == {false, false, false}
+    end
+
+    test "insert on the right" do
+      retain = Op.retain(1)
+      insert = Op.insert("A")
+
+      assert Op.compose(retain, insert) == {false, false, false}
+      assert Op.compose(insert, insert) == {false, false, false}
+    end
+  end
+end


### PR DESCRIPTION
Support attributes in `delete` operation. This boiled down to changing `Delta.push` so that it would merge deletes with identical attributes. I also added tests for `Op.compose` while I was at it.