### PR TITLE
Fix delete attributes being lost on compose

### DIFF
--- a/lib/delta/op.ex
+++ b/lib/delta/op.ex
@@ -386,8 +386,8 @@ defmodule Delta.Op do
     end
   end
 
-  defp take_partial(%{"delete" => full}, length, _opts) do
-    {delete(length), delete(full - length)}
+  defp take_partial(%{"delete" => full} = op, length, _opts) do
+    {delete(length, op["attributes"]), delete(full - length, op["attributes"])}
   end
 
   defp take_partial(%{"retain" => full} = op, length, _opts) do

--- a/test/delta/delta/compose_test.exs
+++ b/test/delta/delta/compose_test.exs
@@ -278,6 +278,24 @@ defmodule Tests.Delta.Compose do
 
       assert Delta.compose(a, b) == expected
     end
+
+    test "overlapping delete and retain" do
+      a = [
+        Op.retain(1),
+        Op.retain(2, %{"bold" => true, "author" => "user1"})
+      ]
+
+      b = [
+        Op.retain(2),
+        Op.delete(2, %{"author" => "user2"})
+      ]
+
+      assert Delta.compose(a, b) == [
+               Op.retain(1),
+               Op.retain(1, %{"bold" => true, "author" => "user1"}),
+               Op.delete(2, %{"author" => "user2"})
+             ]
+    end
   end
 
   describe ".compose/2 (custom embeds)" do

--- a/test/delta/op_test.exs
+++ b/test/delta/op_test.exs
@@ -38,6 +38,14 @@ defmodule Tests.Op do
 
       assert Op.compose(a, b) == {Op.delete(1), Op.retain(1, %{"foo" => true}), false}
     end
+
+    test "retain with attributes + bigger delete with attributes" do
+      a = Op.retain(1, %{"foo" => true})
+      b = Op.delete(2, %{"bar" => true})
+
+      assert Op.compose(a, b) ==
+               {Op.delete(1, %{"bar" => true}), false, Op.delete(1, %{"bar" => true})}
+    end
   end
 
   describe ".compose/2 : retain + retain" do


### PR DESCRIPTION
Fix for a bug when delete attributes can be lost during compose if delete operation needs to be split into multiple.