### PR TITLE
Add Delta.diff/2

### DIFF
--- a/lib/delta.ex
+++ b/lib/delta.ex
@@ -515,7 +515,11 @@ defmodule Delta do
   def diff(base, other) do
     base_string = diffable_string(base)
     other_string = diffable_string(other)
-    diff = Dmp.Diff.main(base_string, other_string)
+
+    diff =
+      base_string
+      |> Dmp.Diff.main(other_string)
+      |> Dmp.Diff.cleanup_semantic()
 
     do_diff(base, other, diff, [], nil, 0)
   end

--- a/lib/delta.ex
+++ b/lib/delta.ex
@@ -513,14 +513,14 @@ defmodule Delta do
   def diff(base, other) when base == other, do: []
 
   def diff(base, other) do
-    base_string = string_to_diff(base)
-    other_string = string_to_diff(other)
+    base_string = diffable_string(base)
+    other_string = diffable_string(other)
     diff = Dmp.Diff.main(base_string, other_string)
 
     do_diff(base, other, diff, [], nil, 0)
   end
 
-  defp string_to_diff(delta) do
+  defp diffable_string(delta) do
     delta
     |> Enum.map(fn
       %{"insert" => str} when is_binary(str) ->

--- a/lib/delta/attr.ex
+++ b/lib/delta/attr.ex
@@ -72,4 +72,20 @@ defmodule Delta.Attr do
   defp merge(a, b, true) do
     Map.merge(a, b)
   end
+
+  @spec diff(a :: maybe_map, b :: maybe_map) :: map
+  def diff(a, b) do
+    a = a || %{}
+    b = b || %{}
+
+    keys = MapSet.new(Map.keys(a) ++ Map.keys(b))
+
+    Enum.reduce(keys, %{}, fn key, attrs ->
+      if a[key] != b[key] do
+        Map.put(attrs, key, b[key])
+      else
+        attrs
+      end
+    end)
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,10 @@ defmodule Delta.MixProject do
 
   # Dependencies
   defp deps do
-    [{:ex_doc, ">= 0.0.0", only: :dev, runtime: false}]
+    [
+      {:diff_match_patch, "~> 0.1.0"},
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
+    ]
   end
 
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "diff_match_patch": {:hex, :diff_match_patch, "0.1.0", "d898f6efb2d668a6fda47ffb576f439629753291a97e5a2fbe3c9fbb03f1efdc", [:mix], [], "hexpm", "732a9ab6740a0526d8656ff3bbf61f078851a130ec9736f16e6306e2f26fc621"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.28", "0bf6546eb7cd6185ae086cbc5d20cd6dbb4b428aad14c02c49f7b554484b4586", [:mix], [], "hexpm", "501cef12286a3231dc80c81352a9453decf9586977f917a96e619293132743fb"},
   "ex_doc": {:hex, :ex_doc, "0.28.5", "3e52a6d2130ce74d096859e477b97080c156d0926701c13870a4e1f752363279", [:mix], [{:earmark_parser, "~> 1.4.19", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "d2c4b07133113e9aa3e9ba27efb9088ba900e9e51caa383919676afdf09ab181"},
   "makeup": {:hex, :makeup, "1.1.0", "6b67c8bc2882a6b6a445859952a602afc1a41c2e08379ca057c0f525366fc3ca", [:mix], [{:nimble_parsec, "~> 1.2.2 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "0a45ed501f4a8897f580eabf99a2e5234ea3e75a4373c8a52824f6e873be57a6"},

--- a/test/delta/delta_test.exs
+++ b/test/delta/delta_test.exs
@@ -243,6 +243,7 @@ defmodule Tests.Delta do
       b = [Op.insert("AB")]
 
       assert [Op.retain(1), Op.insert("B")] == Delta.diff(a, b)
+      assert Delta.compose(a, Delta.diff(a, b)) == b
     end
 
     test "delete" do
@@ -250,6 +251,7 @@ defmodule Tests.Delta do
       b = [Op.insert("A")]
 
       assert [Op.retain(1), Op.delete(1)] == Delta.diff(a, b)
+      assert Delta.compose(a, Delta.diff(a, b)) == b
     end
 
     test "retain" do
@@ -257,6 +259,7 @@ defmodule Tests.Delta do
       b = [Op.insert("A")]
 
       assert [] == Delta.diff(a, b)
+      assert Delta.compose(a, Delta.diff(a, b)) == b
     end
 
     test "format" do
@@ -264,6 +267,7 @@ defmodule Tests.Delta do
       b = [Op.insert("A", %{"bold" => true})]
 
       assert [Op.retain(1, %{"bold" => true})] == Delta.diff(a, b)
+      assert Delta.compose(a, Delta.diff(a, b)) == b
     end
 
     test "object attributes" do
@@ -271,6 +275,7 @@ defmodule Tests.Delta do
       b = [Op.insert("A", %{"font" => %{"family" => "Helvetica", "size" => "15px"}})]
 
       assert [] == Delta.diff(a, b)
+      assert Delta.compose(a, Delta.diff(a, b)) == b
     end
 
     test "embed integer match" do
@@ -278,6 +283,7 @@ defmodule Tests.Delta do
       b = [Op.insert(%{"embed" => 1})]
 
       assert [] == Delta.diff(a, b)
+      assert Delta.compose(a, Delta.diff(a, b)) == b
     end
 
     test "embed integer mismatch" do
@@ -285,6 +291,7 @@ defmodule Tests.Delta do
       b = [Op.insert(%{"embed" => 2})]
 
       assert [Op.delete(1), Op.insert(%{"embed" => 2})] == Delta.diff(a, b)
+      assert Delta.compose(a, Delta.diff(a, b)) == b
     end
 
     test "embed object match" do
@@ -292,6 +299,7 @@ defmodule Tests.Delta do
       b = [Op.insert(%{"image" => "http://example.com"})]
 
       assert [] == Delta.diff(a, b)
+      assert Delta.compose(a, Delta.diff(a, b)) == b
     end
 
     test "embed object mismatch" do
@@ -299,6 +307,7 @@ defmodule Tests.Delta do
       b = [Op.insert(%{"image" => "http://example.com"})]
 
       assert [Op.delete(1), Op.insert(%{"image" => "http://example.com"})] == Delta.diff(a, b)
+      assert Delta.compose(a, Delta.diff(a, b)) == b
     end
 
     test "embed object change" do
@@ -306,6 +315,7 @@ defmodule Tests.Delta do
       b = [Op.insert(%{"image" => "http://example.org"})]
 
       assert [Op.delete(1), Op.insert(%{"image" => "http://example.org"})] == Delta.diff(a, b)
+      assert Delta.compose(a, Delta.diff(a, b)) == b
     end
 
     test "error on non-documents" do
@@ -325,6 +335,8 @@ defmodule Tests.Delta do
                Op.retain(1, %{"italic" => nil, "color" => "red"}),
                Op.delete(1)
              ] == Delta.diff(a, b)
+
+      assert Delta.compose(a, Delta.diff(a, b)) == b
     end
 
     test "combination" do
@@ -338,6 +350,8 @@ defmodule Tests.Delta do
                Op.delete(3),
                Op.insert("og", %{"italic" => true})
              ] == Delta.diff(a, b)
+
+      assert Delta.compose(a, Delta.diff(a, b)) == b
     end
   end
 end

--- a/test/delta/delta_test.exs
+++ b/test/delta/delta_test.exs
@@ -343,12 +343,11 @@ defmodule Tests.Delta do
       a = [Op.insert("Bad", %{"color" => "red"}), Op.insert("cat", %{"color" => "blue"})]
       b = [Op.insert("Good", %{"bold" => true}), Op.insert("dog", %{"italic" => true})]
 
+      # semantic cleanup simplifies this diff
       assert [
-               Op.delete(2),
+               Op.delete(6),
                Op.insert("Good", %{"bold" => true}),
-               Op.retain(1, %{"italic" => true, "color" => nil}),
-               Op.delete(3),
-               Op.insert("og", %{"italic" => true})
+               Op.insert("dog", %{"italic" => true})
              ] == Delta.diff(a, b)
 
       assert Delta.compose(a, Delta.diff(a, b)) == b

--- a/test/delta/delta_test.exs
+++ b/test/delta/delta_test.exs
@@ -1,6 +1,17 @@
 defmodule Tests.Delta do
   use Delta.Support.Case, async: true
-  doctest Delta, only: [compact: 1, concat: 2, push: 2, size: 1, slice: 3, slice_max: 3, split: 3]
+
+  doctest Delta,
+    only: [
+      compact: 1,
+      concat: 2,
+      diff: 2,
+      push: 2,
+      size: 1,
+      slice: 3,
+      slice_max: 3,
+      split: 3
+    ]
 
   # NOTE: {compose, transform, invert} tests are in their
   # dedicated test suites under delta/
@@ -223,6 +234,110 @@ defmodule Tests.Delta do
     @tag skip: true
     test "insert after delete" do
       flunk("implement this")
+    end
+  end
+
+  describe ".diff/2" do
+    test "insert" do
+      a = [Op.insert("A")]
+      b = [Op.insert("AB")]
+
+      assert [Op.retain(1), Op.insert("B")] == Delta.diff(a, b)
+    end
+
+    test "delete" do
+      a = [Op.insert("AB")]
+      b = [Op.insert("A")]
+
+      assert [Op.retain(1), Op.delete(1)] == Delta.diff(a, b)
+    end
+
+    test "retain" do
+      a = [Op.insert("A")]
+      b = [Op.insert("A")]
+
+      assert [] == Delta.diff(a, b)
+    end
+
+    test "format" do
+      a = [Op.insert("A")]
+      b = [Op.insert("A", %{"bold" => true})]
+
+      assert [Op.retain(1, %{"bold" => true})] == Delta.diff(a, b)
+    end
+
+    test "object attributes" do
+      a = [Op.insert("A", %{"font" => %{"family" => "Helvetica", "size" => "15px"}})]
+      b = [Op.insert("A", %{"font" => %{"family" => "Helvetica", "size" => "15px"}})]
+
+      assert [] == Delta.diff(a, b)
+    end
+
+    test "embed integer match" do
+      a = [Op.insert(%{"embed" => 1})]
+      b = [Op.insert(%{"embed" => 1})]
+
+      assert [] == Delta.diff(a, b)
+    end
+
+    test "embed integer mismatch" do
+      a = [Op.insert(%{"embed" => 1})]
+      b = [Op.insert(%{"embed" => 2})]
+
+      assert [Op.delete(1), Op.insert(%{"embed" => 2})] == Delta.diff(a, b)
+    end
+
+    test "embed object match" do
+      a = [Op.insert(%{"image" => "http://example.com"})]
+      b = [Op.insert(%{"image" => "http://example.com"})]
+
+      assert [] == Delta.diff(a, b)
+    end
+
+    test "embed object mismatch" do
+      a = [Op.insert(%{"image" => "http://example.com", "alt" => "overwrite"})]
+      b = [Op.insert(%{"image" => "http://example.com"})]
+
+      assert [Op.delete(1), Op.insert(%{"image" => "http://example.com"})] == Delta.diff(a, b)
+    end
+
+    test "embed object change" do
+      a = [Op.insert(%{"image" => "http://example.com"})]
+      b = [Op.insert(%{"image" => "http://example.org"})]
+
+      assert [Op.delete(1), Op.insert(%{"image" => "http://example.org"})] == Delta.diff(a, b)
+    end
+
+    test "error on non-documents" do
+      a = [Op.insert("A")]
+      b = [Op.retain(1), Op.insert("B")]
+
+      assert_raise RuntimeError, fn -> Delta.diff(a, b) end
+      assert_raise RuntimeError, fn -> Delta.diff(b, a) end
+    end
+
+    test "inconvenient indices" do
+      a = [Op.insert("12", %{"bold" => true}), Op.insert("34", %{"italic" => true})]
+      b = [Op.insert("123", %{"color" => "red"})]
+
+      assert [
+               Op.retain(2, %{"bold" => nil, "color" => "red"}),
+               Op.retain(1, %{"italic" => nil, "color" => "red"}),
+               Op.delete(1)
+             ] == Delta.diff(a, b)
+    end
+
+    test "combination" do
+      a = [Op.insert("Bad", %{"color" => "red"}), Op.insert("cat", %{"color" => "blue"})]
+      b = [Op.insert("Good", %{"bold" => true}), Op.insert("dog", %{"italic" => true})]
+
+      assert [
+               Op.delete(2),
+               Op.insert("Good", %{"bold" => true}),
+               Op.retain(1, %{"italic" => true, "color" => nil}),
+               Op.delete(3),
+               Op.insert("og", %{"italic" => true})
+             ] == Delta.diff(a, b)
     end
   end
 end


### PR DESCRIPTION
Ported the `diff` method [from the JS library](https://github.com/quilljs/delta/blob/5ffb853d645aa5b4c93e42aa52697e2824afc869/src/Delta.ts#L339). Also ported over the tests. Using the [diff_match_patch](https://github.com/pzingg/diff_match_patch/) package for the text diffing.