### PR TITLE
Add diff handler for custom embeds

### DIFF
--- a/lib/delta.ex
+++ b/lib/delta.ex
@@ -584,7 +584,7 @@ defmodule Delta do
 
     delta =
       case {base_op, other_op} do
-        {%{"insert" => str}, %{"insert" => str}} ->
+        {%{"insert" => ins}, %{"insert" => ins}} ->
           attrs = Delta.Attr.diff(base_op["attributes"], other_op["attributes"])
           push(delta, Op.retain(op_len, attrs))
 

--- a/lib/delta/embed_handler.ex
+++ b/lib/delta/embed_handler.ex
@@ -58,4 +58,5 @@ defmodule Delta.EmbedHandler do
   @callback compose(any(), any(), keep_nil? :: boolean()) :: embed()
   @callback transform(any(), any(), priority? :: boolean()) :: embed()
   @callback invert(any(), any()) :: embed()
+  @callback diff(any(), any()) :: embed()
 end

--- a/test/delta/delta/diff_test.exs
+++ b/test/delta/delta/diff_test.exs
@@ -1,0 +1,121 @@
+defmodule Tests.Delta.Diff do
+  use Delta.Support.Case, async: false
+  doctest Delta, only: [diff: 2]
+
+  describe ".diff/2 (basic)" do
+    test "insert" do
+      a = [Op.insert("A")]
+      b = [Op.insert("AB")]
+
+      assert [Op.retain(1), Op.insert("B")] == Delta.diff(a, b)
+      assert Delta.compose(a, Delta.diff(a, b)) == b
+    end
+
+    test "delete" do
+      a = [Op.insert("AB")]
+      b = [Op.insert("A")]
+
+      assert [Op.retain(1), Op.delete(1)] == Delta.diff(a, b)
+      assert Delta.compose(a, Delta.diff(a, b)) == b
+    end
+
+    test "retain" do
+      a = [Op.insert("A")]
+      b = [Op.insert("A")]
+
+      assert [] == Delta.diff(a, b)
+      assert Delta.compose(a, Delta.diff(a, b)) == b
+    end
+
+    test "format" do
+      a = [Op.insert("A")]
+      b = [Op.insert("A", %{"bold" => true})]
+
+      assert [Op.retain(1, %{"bold" => true})] == Delta.diff(a, b)
+      assert Delta.compose(a, Delta.diff(a, b)) == b
+    end
+
+    test "object attributes" do
+      a = [Op.insert("A", %{"font" => %{"family" => "Helvetica", "size" => "15px"}})]
+      b = [Op.insert("A", %{"font" => %{"family" => "Helvetica", "size" => "15px"}})]
+
+      assert [] == Delta.diff(a, b)
+      assert Delta.compose(a, Delta.diff(a, b)) == b
+    end
+
+    test "embed integer match" do
+      a = [Op.insert(%{"embed" => 1})]
+      b = [Op.insert(%{"embed" => 1})]
+
+      assert [] == Delta.diff(a, b)
+      assert Delta.compose(a, Delta.diff(a, b)) == b
+    end
+
+    test "embed integer mismatch" do
+      a = [Op.insert(%{"embed" => 1})]
+      b = [Op.insert(%{"embed" => 2})]
+
+      assert [Op.delete(1), Op.insert(%{"embed" => 2})] == Delta.diff(a, b)
+      assert Delta.compose(a, Delta.diff(a, b)) == b
+    end
+
+    test "embed object match" do
+      a = [Op.insert(%{"image" => "http://example.com"})]
+      b = [Op.insert(%{"image" => "http://example.com"})]
+
+      assert [] == Delta.diff(a, b)
+      assert Delta.compose(a, Delta.diff(a, b)) == b
+    end
+
+    test "embed object mismatch" do
+      a = [Op.insert(%{"image" => "http://example.com", "alt" => "overwrite"})]
+      b = [Op.insert(%{"image" => "http://example.com"})]
+
+      assert [Op.delete(1), Op.insert(%{"image" => "http://example.com"})] == Delta.diff(a, b)
+      assert Delta.compose(a, Delta.diff(a, b)) == b
+    end
+
+    test "embed object change" do
+      a = [Op.insert(%{"image" => "http://example.com"})]
+      b = [Op.insert(%{"image" => "http://example.org"})]
+
+      assert [Op.delete(1), Op.insert(%{"image" => "http://example.org"})] == Delta.diff(a, b)
+      assert Delta.compose(a, Delta.diff(a, b)) == b
+    end
+
+    test "error on non-documents" do
+      a = [Op.insert("A")]
+      b = [Op.retain(1), Op.insert("B")]
+
+      assert_raise RuntimeError, fn -> Delta.diff(a, b) end
+      assert_raise RuntimeError, fn -> Delta.diff(b, a) end
+    end
+
+    test "inconvenient indices" do
+      a = [Op.insert("12", %{"bold" => true}), Op.insert("34", %{"italic" => true})]
+      b = [Op.insert("123", %{"color" => "red"})]
+
+      assert [
+               Op.retain(2, %{"bold" => nil, "color" => "red"}),
+               Op.retain(1, %{"italic" => nil, "color" => "red"}),
+               Op.delete(1)
+             ] == Delta.diff(a, b)
+
+      assert Delta.compose(a, Delta.diff(a, b)) == b
+    end
+
+    test "combination" do
+      a = [Op.insert("Bad", %{"color" => "red"}), Op.insert("cat", %{"color" => "blue"})]
+      b = [Op.insert("Good", %{"bold" => true}), Op.insert("dog", %{"italic" => true})]
+
+      # semantic cleanup simplifies this diff
+      assert [
+               Op.delete(6),
+               Op.insert("Good", %{"bold" => true}),
+               Op.insert("dog", %{"italic" => true})
+             ] == Delta.diff(a, b)
+
+      assert Delta.compose(a, Delta.diff(a, b)) == b
+    end
+  end
+end

--- a/test/delta/delta_test.exs
+++ b/test/delta/delta_test.exs
@@ -5,7 +5,6 @@ defmodule Tests.Delta do
     only: [
       compact: 1,
       concat: 2,
-      diff: 2,
       push: 2,
       size: 1,
       slice: 3,
@@ -13,7 +12,7 @@ defmodule Tests.Delta do
       split: 3
     ]
 
-  # NOTE: {compose, transform, invert} tests are in their
+  # NOTE: {compose, transform, invert, diff} tests are in their
   # dedicated test suites under delta/
 
   describe ".slice/3" do
@@ -234,123 +233,6 @@ defmodule Tests.Delta do
     @tag skip: true
     test "insert after delete" do
       flunk("implement this")
-    end
-  end
-
-  describe ".diff/2" do
-    test "insert" do
-      a = [Op.insert("A")]
-      b = [Op.insert("AB")]
-
-      assert [Op.retain(1), Op.insert("B")] == Delta.diff(a, b)
-      assert Delta.compose(a, Delta.diff(a, b)) == b
-    end
-
-    test "delete" do
-      a = [Op.insert("AB")]
-      b = [Op.insert("A")]
-
-      assert [Op.retain(1), Op.delete(1)] == Delta.diff(a, b)
-      assert Delta.compose(a, Delta.diff(a, b)) == b
-    end
-
-    test "retain" do
-      a = [Op.insert("A")]
-      b = [Op.insert("A")]
-
-      assert [] == Delta.diff(a, b)
-      assert Delta.compose(a, Delta.diff(a, b)) == b
-    end
-
-    test "format" do
-      a = [Op.insert("A")]
-      b = [Op.insert("A", %{"bold" => true})]
-
-      assert [Op.retain(1, %{"bold" => true})] == Delta.diff(a, b)
-      assert Delta.compose(a, Delta.diff(a, b)) == b
-    end
-
-    test "object attributes" do
-      a = [Op.insert("A", %{"font" => %{"family" => "Helvetica", "size" => "15px"}})]
-      b = [Op.insert("A", %{"font" => %{"family" => "Helvetica", "size" => "15px"}})]
-
-      assert [] == Delta.diff(a, b)
-      assert Delta.compose(a, Delta.diff(a, b)) == b
-    end
-
-    test "embed integer match" do
-      a = [Op.insert(%{"embed" => 1})]
-      b = [Op.insert(%{"embed" => 1})]
-
-      assert [] == Delta.diff(a, b)
-      assert Delta.compose(a, Delta.diff(a, b)) == b
-    end
-
-    test "embed integer mismatch" do
-      a = [Op.insert(%{"embed" => 1})]
-      b = [Op.insert(%{"embed" => 2})]
-
-      assert [Op.delete(1), Op.insert(%{"embed" => 2})] == Delta.diff(a, b)
-      assert Delta.compose(a, Delta.diff(a, b)) == b
-    end
-
-    test "embed object match" do
-      a = [Op.insert(%{"image" => "http://example.com"})]
-      b = [Op.insert(%{"image" => "http://example.com"})]
-
-      assert [] == Delta.diff(a, b)
-      assert Delta.compose(a, Delta.diff(a, b)) == b
-    end
-
-    test "embed object mismatch" do
-      a = [Op.insert(%{"image" => "http://example.com", "alt" => "overwrite"})]
-      b = [Op.insert(%{"image" => "http://example.com"})]
-
-      assert [Op.delete(1), Op.insert(%{"image" => "http://example.com"})] == Delta.diff(a, b)
-      assert Delta.compose(a, Delta.diff(a, b)) == b
-    end
-
-    test "embed object change" do
-      a = [Op.insert(%{"image" => "http://example.com"})]
-      b = [Op.insert(%{"image" => "http://example.org"})]
-
-      assert [Op.delete(1), Op.insert(%{"image" => "http://example.org"})] == Delta.diff(a, b)
-      assert Delta.compose(a, Delta.diff(a, b)) == b
-    end
-
-    test "error on non-documents" do
-      a = [Op.insert("A")]
-      b = [Op.retain(1), Op.insert("B")]
-
-      assert_raise RuntimeError, fn -> Delta.diff(a, b) end
-      assert_raise RuntimeError, fn -> Delta.diff(b, a) end
-    end
-
-    test "inconvenient indices" do
-      a = [Op.insert("12", %{"bold" => true}), Op.insert("34", %{"italic" => true})]
-      b = [Op.insert("123", %{"color" => "red"})]
-
-      assert [
-               Op.retain(2, %{"bold" => nil, "color" => "red"}),
-               Op.retain(1, %{"italic" => nil, "color" => "red"}),
-               Op.delete(1)
-             ] == Delta.diff(a, b)
-
-      assert Delta.compose(a, Delta.diff(a, b)) == b
-    end
-
-    test "combination" do
-      a = [Op.insert("Bad", %{"color" => "red"}), Op.insert("cat", %{"color" => "blue"})]
-      b = [Op.insert("Good", %{"bold" => true}), Op.insert("dog", %{"italic" => true})]
-
-      # semantic cleanup simplifies this diff
-      assert [
-               Op.delete(6),
-               Op.insert("Good", %{"bold" => true}),
-               Op.insert("dog", %{"italic" => true})
-             ] == Delta.diff(a, b)
-
-      assert Delta.compose(a, Delta.diff(a, b)) == b
     end
   end
 end

--- a/test/support/test_embed.ex
+++ b/test/support/test_embed.ex
@@ -13,4 +13,7 @@ defmodule Delta.Support.TestEmbed do
 
   @impl true
   defdelegate invert(a, b), to: Delta
+
+  @impl true
+  defdelegate diff(a, b), to: Delta
 end


### PR DESCRIPTION
Part of https://github.com/slab/slab/issues/8899

Support custom diff implementations for embeds. If no handler exists for an embed, use existing behavior of deleting the old op and inserting the new one. If there is a handler, run its diff function and store the result under the embed's key in a retain op.

The diff implementation should maintain the invariant that composing the old delta and the diff results in the new delta.