### PR TITLE
Fix split when splitter returns 0 index

### DIFF
--- a/lib/delta.ex
+++ b/lib/delta.ex
@@ -327,6 +327,9 @@ defmodule Delta do
       {:cont, context} ->
         do_split([first | passed], remaining, func, context, opts)
 
+      0 ->
+        {Enum.reverse(passed), [first | remaining]}
+
       index ->
         case Op.take(first, index, opts) do
           {left, false} ->

--- a/test/delta/delta_test.exs
+++ b/test/delta/delta_test.exs
@@ -211,6 +211,27 @@ defmodule Tests.Delta do
     end
   end
 
+  describe ".split/3" do
+    test "split at op boundary" do
+      delta = [
+        Op.insert("hello"),
+        Op.insert(%{"code-embed" => []}),
+        Op.insert("world")
+      ]
+
+      # this splitter should split the delta immediately before the first embed
+      assert Delta.split(delta, fn
+               %{"insert" => text}, _ when is_binary(text) -> :cont
+               _, _ -> 0
+             end) ==
+               {[Op.insert("hello")],
+                [
+                  Op.insert(%{"code-embed" => []}),
+                  Op.insert("world")
+                ]}
+    end
+  end
+
   describe ".push/2" do
     test "push merge" do
       delta =


### PR DESCRIPTION
Another bug I found while working on https://github.com/slab/slab/pull/9371

Using `Op.take` when the splitter returns 0 (meaning to put the entire current op on the right side of the split) doesn't do the right thing:

- For text, it would add an extraneous `{"insert":""}` op to the end of the left side
- For embeds, it puts the embed op on the left side of the split instead of the right

The split function used when passing an integer index doesn't run into this, because it special cases 0 and otherwise catches this case on the previous op. But if you're using a custom split function where the logic depends on seeing the op before deciding it should go on the right of the split, you hit this problem. The fix is to add another case for when the splitter function returns 0.