### PR TITLE
Reshape embed diffing

### DIFF
--- a/lib/delta/embed_handler.ex
+++ b/lib/delta/embed_handler.ex
@@ -58,5 +58,7 @@ defmodule Delta.EmbedHandler do
   @callback compose(any(), any(), keep_nil? :: boolean()) :: embed()
   @callback transform(any(), any(), priority? :: boolean()) :: embed()
   @callback invert(any(), any()) :: embed()
-  @callback diff(any(), any()) :: embed()
+  @callback diff(Delta.Op.t(), Delta.Op.t()) :: Delta.t()
+
+  @optional_callbacks diff: 2
 end

--- a/lib/delta/embed_handler.ex
+++ b/lib/delta/embed_handler.ex
@@ -58,7 +58,7 @@ defmodule Delta.EmbedHandler do
   @callback compose(any(), any(), keep_nil? :: boolean()) :: embed()
   @callback transform(any(), any(), priority? :: boolean()) :: embed()
   @callback invert(any(), any()) :: embed()
-  @callback diff(Delta.Op.t(), Delta.Op.t()) :: Delta.t()
+  @callback diff(Delta.Op.insert_op(), Delta.Op.insert_op()) :: Delta.t()
 
   @optional_callbacks diff: 2
 end

--- a/test/delta/delta/diff_test.exs
+++ b/test/delta/delta/diff_test.exs
@@ -122,7 +122,7 @@ defmodule Tests.Delta.Diff do
   end
 
   describe ".diff/2 (custom embeds)" do
-    @describetag custom_embeds: [TestEmbed]
+    @describetag custom_embeds: [TestEmbed, QuoteEmbed]
 
     test "equal strings" do
       a = [Op.insert("A")]
@@ -188,6 +188,27 @@ defmodule Tests.Delta.Diff do
              ] == Delta.diff(a, b)
 
       assert Delta.compose(a, Delta.diff(a, b)) == b
+    end
+
+    test "different embeds" do
+      a = [Op.insert(%{"delta" => [Op.insert("hello world")]})]
+      b = [Op.insert(%{"quote" => [Op.insert("goodbye world")]})]
+
+      assert [
+               Op.delete(1),
+               Op.insert(%{"quote" => [Op.insert("goodbye world")]})
+             ] == Delta.diff(a, b)
+
+      assert Delta.compose(a, Delta.diff(a, b)) == b
+    end
+
+    test "embeds without handler diff attributes if equal" do
+      a = [Op.insert(%{"quote" => [Op.insert("hello world")]}, %{"author" => "A"})]
+      b = [Op.insert(%{"quote" => [Op.insert("hello world")]}, %{"author" => "B"})]
+
+      assert [
+               Op.retain(1, %{"author" => "B"})
+             ] == Delta.diff(a, b)
     end
   end
 end

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -6,7 +6,7 @@ defmodule Delta.Support.Case do
     quote do
       alias Delta
       alias Delta.{Op, Attr}
-      alias Delta.Support.TestEmbed
+      alias Delta.Support.{TestEmbed, QuoteEmbed}
     end
   end
 

--- a/test/support/quote_embed.ex
+++ b/test/support/quote_embed.ex
@@ -1,0 +1,16 @@
+defmodule Delta.Support.QuoteEmbed do
+  @moduledoc false
+  @behaviour Delta.EmbedHandler
+
+  @impl true
+  def name, do: "quote"
+
+  @impl true
+  def compose(a, b, _keep_nil), do: Delta.compose(a, b)
+
+  @impl true
+  defdelegate transform(a, b, priority?), to: Delta
+
+  @impl true
+  defdelegate invert(a, b), to: Delta
+end

--- a/test/support/test_embed.ex
+++ b/test/support/test_embed.ex
@@ -15,5 +15,15 @@ defmodule Delta.Support.TestEmbed do
   defdelegate invert(a, b), to: Delta
 
   @impl true
-  defdelegate diff(a, b), to: Delta
+  def diff(a, b) do
+    attr_diff = Delta.Attr.diff(a["attributes"], b["attributes"])
+
+    diff =
+      case Delta.diff(a["insert"]["delta"], b["insert"]["delta"]) do
+        [] -> 1
+        delta -> %{"delta" => delta}
+      end
+
+    [Delta.Op.retain(diff, attr_diff)]
+  end
 end


### PR DESCRIPTION
Changes:
1. Fix a bug when code always assumed two embeds being diffed are of the same type
2. Make embed handler fully responsible for diffing two operations, including the case when `insert` content is identical. In order to do this we need to change `diff/2` callback's signature from `diff(any(), any()) :: embed()` to `diff(Op.t(), Op.t()) :: Delta.t()`. For `do_diff` internals the change is fairly straightforward – once it came down to diffing two ops of the same length, we check if we should delegate to embed handler or do a simple equality + attr diffing. Oh, and since we now handle the case when `diff` callback isn't defined by embed, I made it optional.