### PR TITLE
Use String.myers_difference/2 instead of Dmp.Diff.main/2

### DIFF
--- a/lib/delta.ex
+++ b/lib/delta.ex
@@ -529,7 +529,12 @@ defmodule Delta do
 
     diff =
       base_string
-      |> Dmp.Diff.main(other_string)
+      |> String.myers_difference(other_string)
+      |> Enum.map(fn
+        {:eq, str} -> {:equal, str}
+        {:del, str} -> {:delete, str}
+        {:ins, str} -> {:insert, str}
+      end)
       |> Dmp.Diff.cleanup_semantic()
 
     do_diff(base, other, diff, [], nil, 0)


### PR DESCRIPTION
As was discussed here https://github.com/slab/slab/issues/8898#issuecomment-1698221774, it looks like `String.myers_difference/2` can be used as a drop in replacement for `Dmp.Diff.main/2`.

I found another example of delta that was particularly slow to diff, so I used it as an opportunity to compare these two approaches. Myers difference is a lot faster (fraction of second vs ~5 seconds), but it does produce a different output. However, the difference seems to also be in favour of `String.myers_difference`. More info here: https://the.slab.com/posts/diff-match-patch-vs-myers-difference-in-delta-elixir-n7bjm6wz

This PR makes the switch.