### PR TITLE
Simplified dependencies

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-elixir 1.13.4-otp-24
-erlang 24.3.4.2

--- a/README.md
+++ b/README.md
@@ -210,6 +210,20 @@ base |> Delta.compose(change) |> Delta.compose(inverted) == base
 
 <br>
 
+## Global Library options
+
+In your application, these are settable in `config.exs` by doing:
+
+`config :delta, :<option>, <value>`
+
+### Compile-time
+`timeout`: timeout (in seconds) for the diffing operation to complete.  If you don't set this, there is no timeout.
+`diff_fast`: (boolean) if true, performs a diff that is faster but is a less optimal diff
+
+### Runtime
+
+`custom_embeds`: ... insert description here ...
+
 ## Contributing
 
 - [Fork][github-fork], Enhance, Send PR

--- a/lib/delta.ex
+++ b/lib/delta.ex
@@ -519,6 +519,10 @@ defmodule Delta do
       iex> Delta.compose(a, diff) == b
       true
   """
+
+  @check_lines Application.compile_env(:delta, :diff_fast, false)
+  @timeout Application.compile_env(:delta, :diff_timeout, nil)
+
   @doc since: "0.4.0"
   @spec diff(t, t) :: t
   def diff(base, other)
@@ -531,10 +535,17 @@ defmodule Delta do
 
     diff =
       base_string
-      |> :diffy.diff(other_string)
+      |> Dmp.Diff.compute(other_string, @check_lines, deadline())
       |> Dmp.Diff.cleanup_semantic()
 
     do_diff(base, other, diff, [], nil, 0)
+  end
+
+  @compile {:inline, deadline: 0}
+  if @timeout do
+    defp deadline, do: :os.system_time(:millsecond) + round(@timeout * 1000)
+  else
+    defp deadline, do: :never
   end
 
   defp diffable_string(delta) do

--- a/mix.exs
+++ b/mix.exs
@@ -50,7 +50,6 @@ defmodule Delta.MixProject do
   defp deps do
     [
       {:diff_match_patch, "~> 0.2"},
-      {:diffy, "~> 1.1"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]
   end


### PR DESCRIPTION
not sure if this works with your usecases (might need a performance regression test) but this PR removes the :diffy dependency and replaces with just a diff_match_patch dependency.  Not offended if you don't merge the PR.